### PR TITLE
Support Begin Patch diff format

### DIFF
--- a/tests/test_parse_diff_per_file.py
+++ b/tests/test_parse_diff_per_file.py
@@ -169,5 +169,19 @@ def test_parse_diff_per_file_unconventional_header():
     assert "+++ game.js" in patch, "Expected patch to include '+++ game.js'"
     assert "+let player" in patch, "Expected patch to include added lines"
 
+def test_begin_patch_format():
+    diff_text = """*** Begin Patch
+*** Update File: services/clerkReportPdf.tsx
+@@
+-changes1
++changes2
+*** End Patch"""
+    result = parse_diff_per_file(diff_text)
+    assert len(result) == 1
+    file_path, patch = result[0]
+    assert file_path == "services/clerkReportPdf.tsx"
+    assert "-changes1" in patch
+    assert "+changes2" in patch
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend diff parser to understand `*** Begin Patch` / `*** Update File` style patches
- add regression test for parsing the new patch format

## Testing
- `PYTHONPATH=. pytest tests/test_parse_diff_per_file.py -k begin_patch_format -q`
- `PYTHONPATH=. pytest -q` *(fails: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443): Max retries exceeded with url: /encodings/o200k_base.tiktoken (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_b_689ce1207dcc83329349bc072eb114f8