### PR TITLE
Support interleaved --apply and filename arguments

### DIFF
--- a/gptdiff/gptdiff.py
+++ b/gptdiff/gptdiff.py
@@ -535,7 +535,12 @@ def parse_arguments():
     parser.add_argument('--nowarn', action='store_true', help='Disable large token warning')
     parser.add_argument('--anthropic_budget_tokens', type=int, default=None, help='Budget tokens for Anthropic extended thinking')
     parser.add_argument('--verbose', action='store_true', help='Enable verbose output with detailed information')
-    return parser.parse_args()
+
+    # Allow optional arguments like --apply to appear before or after file paths
+    parse_fn = parser.parse_args
+    if hasattr(parser, 'parse_intermixed_args'):
+        parse_fn = parser.parse_intermixed_args
+    return parse_fn()
 
 def absolute_to_relative(absolute_path):
     cwd = os.getcwd()

--- a/tests/test_argparse_interleaving.py
+++ b/tests/test_argparse_interleaving.py
@@ -1,0 +1,21 @@
+import sys
+from unittest import mock
+
+import gptdiff.gptdiff as gptdiff
+
+
+def parse(argv):
+    with mock.patch.object(sys, 'argv', argv):
+        return gptdiff.parse_arguments()
+
+
+def test_apply_after_file():
+    args = parse(['gptdiff', 'prompt', 'file.js', '--apply'])
+    assert args.apply is True
+    assert args.files == ['file.js']
+
+
+def test_apply_before_file():
+    args = parse(['gptdiff', 'prompt', '--apply', 'file.js'])
+    assert args.apply is True
+    assert args.files == ['file.js']


### PR DESCRIPTION
## Summary
- allow `--apply` flag to be placed before or after file paths by using `parse_intermixed_args`
- add tests ensuring both argument orders are supported

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ProxyError: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443) ...)*
- `PYTHONPATH=. pytest tests/test_argparse_interleaving.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68bdcd2beac48332a3eeec54bce62ea3