### PR TITLE
docs: add top banner linking to gptdiff-js + live demos

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ extra_css:
 
 theme:
   name: material
+  custom_dir: overrides
   features:
     - content.code.annotate
   palette:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{#
+  Top announcement bar shown on every page — mirrors the banner on the
+  gptdiff-js example pages. Points at the browser port and its live demos.
+#}
+{% block announce %}
+  <a href="https://github.com/255BITS/gptdiff-js" target="_blank" rel="noopener">gptdiff-js</a>
+  — run gptdiff in the browser, no command line
+  &nbsp;·&nbsp;
+  <a href="https://255bits.github.io/gptdiff-js-examples/" target="_blank" rel="noopener">live demos</a>
+{% endblock %}


### PR DESCRIPTION
Adds a top announcement banner to every docs page on gptdiff.255labs.xyz, mirroring the banner on the gptdiff-js example pages.

## What
- New `overrides/main.html` that overrides Material's `{% block announce %}` with a banner linking to **gptdiff-js** (browser port) and its **live demos**.
- `mkdocs.yml`: set `theme.custom_dir: overrides`.

## Why
Cross-promote the in-browser way to use gptdiff (no command line) from the docs site, matching the framing already in the README.

## Verification
- `mkdocs build` (strict mode) passes.
- Banner renders inside Material's `<aside class="md-banner">` on `index` and deep pages (e.g. `cli`).

Merging triggers the `Deploy Documentation` workflow → live at https://gptdiff.255labs.xyz/

🤖 Generated with [Claude Code](https://claude.com/claude-code)