### PR TITLE
Fix dead links; point docs & homepage at live URLs

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-patchling.255labs.xyz

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ print(updated["main.py"])
 
 Files in, files out. No filesystem access required, no agent harness. The hard part — applying an LLM-generated diff that `git apply` would reject — is what `smartapply` solves: per-file, AI-assisted patch resolution that survives fuzzy hunks, renames, new files, and deletions.
 
-📚 Full documentation at [patchling.255labs.xyz](https://patchling.255labs.xyz)
+📚 Full documentation at [255bits.github.io/patchling-py](https://255bits.github.io/patchling-py)
 
 Prefer the browser? **[patchling](https://github.com/255BITS/patchling)** is a JavaScript port of
 `generateDiff` + `smartapply` — try the **[live demos →](https://255bits.github.io/patchling-examples/)**.
@@ -94,7 +94,7 @@ See [examples/usage_example.py](examples/usage_example.py) for a runnable versio
 - `build_environment(files: dict[str, str]) -> str` — serializes a files dict into the environment string `generate_diff` expects.
 - `load_project_files(path, cwd) -> dict` / `save_files(files, base_dir)` — optional filesystem helpers for when you *do* want to read/write a real project (respects `.gitignore` and `.gptignore`).
 
-Full signatures, error handling, and edge cases: [API Reference](https://patchling.255labs.xyz/api).
+Full signatures, error handling, and edge cases: [API Reference](https://255bits.github.io/patchling-py/api).
 
 **Pipeline example** — sequential transformations over an in-memory codebase:
 
@@ -166,7 +166,7 @@ patchling "Add type hints to all functions" --apply
 patchling "Add logging" src/api/ src/utils/helpers.py
 ```
 
-Useful flags: `--model`, `--temperature`, `--prepend <file>` (custom instructions), `--image <path>` (visual context), `--nobeep`. Full list: [CLI Reference](https://patchling.255labs.xyz/cli).
+Useful flags: `--model`, `--temperature`, `--prepend <file>` (custom instructions), `--image <path>` (visual context), `--nobeep`. Full list: [CLI Reference](https://255bits.github.io/patchling-py/cli).
 
 Because changes arrive as diffs, the CLI is git-native: review with `git diff`, keep with `git add -p`, discard with `git checkout .`.
 
@@ -179,7 +179,7 @@ patchling-apply path/to/diff.patch
 patchling-apply --diff "<diff text>"
 ```
 
-Options: `--project-dir`, `--model`, `--max_tokens`, `--nobeep`. Details: [patchling-apply docs](https://patchling.255labs.xyz/patchling-apply).
+Options: `--project-dir`, `--model`, `--max_tokens`, `--nobeep`. Details: [patchling-apply docs](https://255bits.github.io/patchling-py/patchling-apply).
 
 ### Agent loops
 
@@ -193,7 +193,7 @@ while true; do
 done
 ```
 
-One overnight test-coverage loop took a project from 18 to 127 test cases. Recipes and guardrails: [Automation Guide](https://patchling.255labs.xyz/examples/automation).
+One overnight test-coverage loop took a project from 18 to 127 test cases. Recipes and guardrails: [Automation Guide](https://255bits.github.io/patchling-py/examples/automation).
 
 ---
 
@@ -206,7 +206,7 @@ pytest tests/
 
 ## Documentation
 
-Docs live at [patchling.255labs.xyz](https://patchling.255labs.xyz). To preview locally:
+Docs live at [255bits.github.io/patchling-py](https://255bits.github.io/patchling-py). To preview locally:
 
 ```bash
 pip install .[docs]

--- a/docs/patchling-apply.md
+++ b/docs/patchling-apply.md
@@ -58,4 +58,4 @@ patchling-apply's AI-powered smart apply resolves these automatically, keeping y
 
 For production-ready loop patterns and real metrics (18→127 tests, 8 SQL injections→0), see the [Agent Loops Guide](examples/automation.md).
 
-For further details about Patchling and its companion tools, please refer to the [Patchling Documentation](https://patchling.255labs.xyz).
+For further details about Patchling and its companion tools, please refer to the [Patchling Documentation](https://255bits.github.io/patchling-py).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Patchling
+site_url: https://255bits.github.io/patchling-py/
 docs_dir: docs
 site_dir: site
 strict: true
@@ -34,7 +35,6 @@ nav:
       - Contributing Guide: development/contributing.md
   - Troubleshooting: troubleshooting.md
 extra:
-  cname: patchling.255labs.xyz
   social:
     - name: nanoodle.com
       icon: fontawesome/solid/diagram-project

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {#
-  Top announcement bar shown on every page — mirrors the banner on the
-  gptdiff-js example pages. Points at the browser port and its live demos.
+  Top announcement bar shown on every page. Points at patchling.app (the
+  hub for both the JS and Python ports) and the live browser demos.
 #}
 {% block announce %}
-  <a href="https://github.com/255BITS/gptdiff-js" target="_blank" rel="noopener">gptdiff-js</a>
-  — run gptdiff in the browser, no command line
+  <a href="https://patchling.app" target="_blank" rel="noopener">patchling.app</a>
+  — natural-language code patching for JavaScript &amp; Python
   &nbsp;·&nbsp;
-  <a href="https://255bits.github.io/gptdiff-js-examples/" target="_blank" rel="noopener">live demos</a>
+  <a href="https://255bits.github.io/patchling-examples/" target="_blank" rel="noopener">live demos</a>
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author='255labs',
     url='https://github.com/255BITS/patchling-py',
     project_urls={
-        'Documentation': 'https://patchling.255labs.xyz',
+        'Documentation': 'https://255bits.github.io/patchling-py',
         'Source': 'https://github.com/255BITS/patchling-py',
         'Browser/Node runtime (npm)': 'https://www.npmjs.com/package/patchling',
         'Built with patchling (nanoodle)': 'https://nanoodle.com',


### PR DESCRIPTION
Sweeps every link in the repo and fixes the broken ones.

## Fixed
- **Dead docs domain** `patchling.255labs.xyz` (didn't resolve) → live `255bits.github.io/patchling-py` across README, `setup.py`, and `docs/`.
- **404 demos link** in the site banner (`gptdiff-js-examples`) → `patchling-examples`; stale `gptdiff-js` banner → **patchling.app**, framed as JS + Python.
- **SEO**: added `site_url` to `mkdocs.yml` (was missing, so no canonical tags / broken sitemap); removed dead `cname` and root `CNAME`.

## Also (repo settings, already applied)
- GitHub repo homepage was the dead `gptdiff.255labs.xyz` → set to `https://patchling.app`.

All target URLs verified live (200). npm `patchling@0.2.0` confirmed published via registry (curl 403 was just bot-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)